### PR TITLE
*bugfix) file_rec/git print directory right;

### DIFF
--- a/autoload/unite/sources/rec.vim
+++ b/autoload/unite/sources/rec.vim
@@ -383,7 +383,7 @@ function! s:source_file_git.gather_candidates(args, context) "{{{
     return []
   endif
 
-  let a:context.source__directory = getcwd()
+  let a:context.source__directory = s:get_path(a:args, a:context)
   let directory = a:context.source__directory
   if finddir('.git', ';') == ''
     " Not in git directory.
@@ -409,7 +409,7 @@ function! s:source_file_git.gather_candidates(args, context) "{{{
   endif
 
   let command = g:unite_source_rec_git_command
-        \ . ' ls-files ' . join(a:args)
+        \ . ' ls-files --full-name ' . join(a:args)
   let args = split(command) + a:args
   if empty(args) || !executable(args[0])
     call unite#print_source_message('git command : "'.


### PR DESCRIPTION
First line 'let a:context.source__directory = s:get_path(a:args, a:context)', I think it is a bug, cause other file_rec all show the directory user pass to it through.

Second line: I add --full-name, same as above, file_rec show the file from the user passed directory which metioned above. Without it, I got too many "../.../../../" in the result, and make me filtering the result working bad.

At least I have used these in my own git scripts, these worked so better.
